### PR TITLE
Adding #include <QButtonGroup>

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -27,6 +27,7 @@
 #include <QScrollBar>
 #include <QSettings>
 #include <QTextDocument>
+#include <QButtonGroup>
 
 static const std::array<int, 9> confTargets = { {2, 4, 6, 12, 24, 48, 144, 504, 1008} };
 int getConfTargetForIndex(int index) {


### PR DESCRIPTION
XSN Qt wallet fails to build on 64bit Gentoo on Raspberry Pi 3 B+:
```
qt/sendcoinsdialog.cpp: In constructor ‘SendCoinsDialog::SendCoinsDialog(const PlatformStyle*, QWidget*)’:
qt/sendcoinsdialog.cpp:107:37: error: invalid use of incomplete type ‘class QButtonGroup’
     groupFee = new QButtonGroup(this);
                                     ^
In file included from qt/sendcoinsdialog.cpp:5:0:
./qt/sendcoinsdialog.h:19:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
       ^~~~~~~~~~~~
qt/sendcoinsdialog.cpp:109:13: error: invalid use of incomplete type ‘class QButtonGroup’
     groupFee->addButton(ui->radioSmartFee, 0);
             ^~
In file included from qt/sendcoinsdialog.cpp:5:0:
./qt/sendcoinsdialog.h:19:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
       ^~~~~~~~~~~~
qt/sendcoinsdialog.cpp:109:15: error: invalid use of incomplete type ‘class QButtonGroup’
     groupFee->addButton(ui->radioSmartFee, 0);
               ^~~~~~~~~
In file included from qt/sendcoinsdialog.cpp:5:0:
./qt/sendcoinsdialog.h:19:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
       ^~~~~~~~~~~~
qt/sendcoinsdialog.cpp:110:13: error: invalid use of incomplete type ‘class QButtonGroup’
     groupFee->addButton(ui->radioCustomFee, 1);
             ^~
In file included from qt/sendcoinsdialog.cpp:5:0:
./qt/sendcoinsdialog.h:19:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
       ^~~~~~~~~~~~
qt/sendcoinsdialog.cpp:110:15: error: invalid use of incomplete type ‘class QButtonGroup’
     groupFee->addButton(ui->radioCustomFee, 1);
               ^~~~~~~~~
In file included from qt/sendcoinsdialog.cpp:5:0:
./qt/sendcoinsdialog.h:19:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
       ^~~~~~~~~~~~
qt/sendcoinsdialog.cpp:129:13: error: invalid use of incomplete type ‘class QButtonGroup’
     groupFee->setId(ui->radioSmartFee, 0);
             ^~
In file included from qt/sendcoinsdialog.cpp:5:0:
./qt/sendcoinsdialog.h:19:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
       ^~~~~~~~~~~~
qt/sendcoinsdialog.cpp:129:15: error: invalid use of incomplete type ‘class QButtonGroup’
     groupFee->setId(ui->radioSmartFee, 0);
               ^~~~~
In file included from qt/sendcoinsdialog.cpp:5:0:
./qt/sendcoinsdialog.h:19:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
       ^~~~~~~~~~~~
qt/sendcoinsdialog.cpp:130:13: error: invalid use of incomplete type ‘class QButtonGroup’
     groupFee->setId(ui->radioCustomFee, 1);
             ^~
In file included from qt/sendcoinsdialog.cpp:5:0:
./qt/sendcoinsdialog.h:19:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
       ^~~~~~~~~~~~
qt/sendcoinsdialog.cpp:130:15: error: invalid use of incomplete type ‘class QButtonGroup’
     groupFee->setId(ui->radioCustomFee, 1);
               ^~~~~
In file included from qt/sendcoinsdialog.cpp:5:0:
./qt/sendcoinsdialog.h:19:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
       ^~~~~~~~~~~~
qt/sendcoinsdialog.cpp:131:13: error: invalid use of incomplete type ‘class QButtonGroup’
     groupFee->button((int)std::max(0, std::min(1, settings.value("nFeeRadio").toInt())))->setChecked(true);
             ^~
In file included from qt/sendcoinsdialog.cpp:5:0:
./qt/sendcoinsdialog.h:19:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
       ^~~~~~~~~~~~
qt/sendcoinsdialog.cpp:131:15: error: invalid use of incomplete type ‘class QButtonGroup’
     groupFee->button((int)std::max(0, std::min(1, settings.value("nFeeRadio").toInt())))->setChecked(true);
               ^~~~~~
In file included from qt/sendcoinsdialog.cpp:5:0:
./qt/sendcoinsdialog.h:19:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
       ^~~~~~~~~~~~
qt/sendcoinsdialog.cpp: In member function ‘void SendCoinsDialog::setModel(WalletModel*)’:
qt/sendcoinsdialog.cpp:182:93: error: no matching function for call to ‘SendCoinsDialog::connect(QButtonGroup*&, const char*, SendCoinsDialog*, const char*)’
         connect(groupFee, SIGNAL(buttonClicked(int)), this, SLOT(updateFeeSectionControls()));
                                                                                             ^
In file included from /usr/include/qt5/QtCore/qiodevice.h:45:0,
                 from /usr/include/qt5/QtCore/qdatastream.h:44,
                 from /usr/include/qt5/QtGui/qregion.h:49,
                 from /usr/include/qt5/QtGui/qevent.h:45,
                 from /usr/include/qt5/QtGui/QList:1,
                 from ./qt/paymentrequestplus.h:19,
                 from ./qt/walletmodel.h:13,
                 from ./qt/sendcoinsdialog.h:8,
                 from qt/sendcoinsdialog.cpp:5:
/usr/include/qt5/QtCore/qobject.h:208:36: note: candidate: static QMetaObject::Connection QObject::connect(const QObject*, const char*, const QObject*, const char*, Qt::ConnectionType)
     static QMetaObject::Connection connect(const QObject *sender, const char *signal,
                                    ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:208:36: note:   no known conversion for argument 1 from ‘QButtonGroup*’ to ‘const QObject*’
/usr/include/qt5/QtCore/qobject.h:211:36: note: candidate: static QMetaObject::Connection QObject::connect(const QObject*, const QMetaMethod&, const QObject*, const QMetaMethod&, Qt::ConnectionType)
     static QMetaObject::Connection connect(const QObject *sender, const QMetaMethod &signal,
                                    ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:211:36: note:   no known conversion for argument 1 from ‘QButtonGroup*’ to ‘const QObject*’
/usr/include/qt5/QtCore/qobject.h:463:32: note: candidate: QMetaObject::Connection QObject::connect(const QObject*, const char*, const char*, Qt::ConnectionType) const
 inline QMetaObject::Connection QObject::connect(const QObject *asender, const char *asignal,
                                ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:463:32: note:   no known conversion for argument 1 from ‘QButtonGroup*’ to ‘const QObject*’
/usr/include/qt5/QtCore/qobject.h:228:43: note: candidate: template<class Func1, class Func2> static QMetaObject::Connection QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, const typename QtPrivate::FunctionPointer<Func2>::Object*, Func2, Qt::ConnectionType)
     static inline QMetaObject::Connection connect(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal,
                                           ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:228:43: note:   template argument deduction/substitution failed:
/usr/include/qt5/QtCore/qobject.h: In substitution of ‘template<class Func1, class Func2> static QMetaObject::Connection QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, const typename QtPrivate::FunctionPointer<Func2>::Object*, Func2, Qt::ConnectionType) [with Func1 = const char*; Func2 = const char*]’:
qt/sendcoinsdialog.cpp:182:93:   required from here
/usr/include/qt5/QtCore/qobject.h:228:43: error: no type named ‘Object’ in ‘struct QtPrivate::FunctionPointer<const char*>’
/usr/include/qt5/QtCore/qobject.h:260:13: note: candidate: template<class Func1, class Func2> static typename std::enable_if<((int)(QtPrivate::FunctionPointer<Func2>::ArgumentCount) >= 0), QMetaObject::Connection>::type QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, Func2)
             connect(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal, Func2 slot)
             ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:260:13: note:   template argument deduction/substitution failed:
qt/sendcoinsdialog.cpp:182:93: note:   candidate expects 3 arguments, 4 provided
         connect(groupFee, SIGNAL(buttonClicked(int)), this, SLOT(updateFeeSectionControls()));
                                                                                             ^
In file included from /usr/include/qt5/QtCore/qiodevice.h:45:0,
                 from /usr/include/qt5/QtCore/qdatastream.h:44,
                 from /usr/include/qt5/QtGui/qregion.h:49,
                 from /usr/include/qt5/QtGui/qevent.h:45,
                 from /usr/include/qt5/QtGui/QList:1,
                 from ./qt/paymentrequestplus.h:19,
                 from ./qt/walletmodel.h:13,
                 from ./qt/sendcoinsdialog.h:8,
                 from qt/sendcoinsdialog.cpp:5:
/usr/include/qt5/QtCore/qobject.h:269:13: note: candidate: template<class Func1, class Func2> static typename std::enable_if<(((int)(QtPrivate::FunctionPointer<Func2>::ArgumentCount) >= 0) && (! QtPrivate::FunctionPointer<Func2>::IsPointerToMemberFunction)), QMetaObject::Connection>::type QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, const QObject*, Func2, Qt::ConnectionType)
             connect(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal, const QObject *context, Func2 slot,
             ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:269:13: note:   template argument deduction/substitution failed:
/usr/include/qt5/QtCore/qobject.h: In substitution of ‘template<class Func1, class Func2> static typename std::enable_if<(((int)(QtPrivate::FunctionPointer<Func2>::ArgumentCount) >= 0) && (! QtPrivate::FunctionPointer<Func2>::IsPointerToMemberFunction)), QMetaObject::Connection>::type QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, const QObject*, Func2, Qt::ConnectionType) [with Func1 = const char*; Func2 = const char*]’:
qt/sendcoinsdialog.cpp:182:93:   required from here
/usr/include/qt5/QtCore/qobject.h:269:13: error: no type named ‘type’ in ‘struct std::enable_if<false, QMetaObject::Connection>’
/usr/include/qt5/QtCore/qobject.h:300:13: note: candidate: template<class Func1, class Func2> static typename std::enable_if<(QtPrivate::FunctionPointer<Func2>::ArgumentCount == -1), QMetaObject::Connection>::type QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, Func2)
             connect(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal, Func2 slot)
             ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:300:13: note:   template argument deduction/substitution failed:
qt/sendcoinsdialog.cpp:182:93: note:   candidate expects 3 arguments, 4 provided
         connect(groupFee, SIGNAL(buttonClicked(int)), this, SLOT(updateFeeSectionControls()));
                                                                                             ^
In file included from /usr/include/qt5/QtCore/qiodevice.h:45:0,
                 from /usr/include/qt5/QtCore/qdatastream.h:44,
                 from /usr/include/qt5/QtGui/qregion.h:49,
                 from /usr/include/qt5/QtGui/qevent.h:45,
                 from /usr/include/qt5/QtGui/QList:1,
                 from ./qt/paymentrequestplus.h:19,
                 from ./qt/walletmodel.h:13,
                 from ./qt/sendcoinsdialog.h:8,
                 from qt/sendcoinsdialog.cpp:5:
/usr/include/qt5/QtCore/qobject.h:308:13: note: candidate: template<class Func1, class Func2> static typename std::enable_if<(QtPrivate::FunctionPointer<Func2>::ArgumentCount == -1), QMetaObject::Connection>::type QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, const QObject*, Func2, Qt::ConnectionType)
             connect(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal, const QObject *context, Func2 slot,
             ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:308:13: note:   template argument deduction/substitution failed:
/usr/include/qt5/QtCore/qobject.h: In substitution of ‘template<class Func1, class Func2> static typename std::enable_if<(QtPrivate::FunctionPointer<Func2>::ArgumentCount == -1), QMetaObject::Connection>::type QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, const QObject*, Func2, Qt::ConnectionType) [with Func1 = const char*; Func2 = const char*]’:
qt/sendcoinsdialog.cpp:182:93:   required from here
/usr/include/qt5/QtCore/qobject.h:308:13: error: no type named ‘Object’ in ‘struct QtPrivate::FunctionPointer<const char*>’
qt/sendcoinsdialog.cpp:183:92: error: no matching function for call to ‘SendCoinsDialog::connect(QButtonGroup*&, const char*, SendCoinsDialog*, const char*)’
         connect(groupFee, SIGNAL(buttonClicked(int)), this, SLOT(coinControlUpdateLabels()));
                                                                                            ^
In file included from /usr/include/qt5/QtCore/qiodevice.h:45:0,
                 from /usr/include/qt5/QtCore/qdatastream.h:44,
                 from /usr/include/qt5/QtGui/qregion.h:49,
                 from /usr/include/qt5/QtGui/qevent.h:45,
                 from /usr/include/qt5/QtGui/QList:1,
                 from ./qt/paymentrequestplus.h:19,
                 from ./qt/walletmodel.h:13,
                 from ./qt/sendcoinsdialog.h:8,
                 from qt/sendcoinsdialog.cpp:5:
/usr/include/qt5/QtCore/qobject.h:208:36: note: candidate: static QMetaObject::Connection QObject::connect(const QObject*, const char*, const QObject*, const char*, Qt::ConnectionType)
     static QMetaObject::Connection connect(const QObject *sender, const char *signal,
                                    ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:208:36: note:   no known conversion for argument 1 from ‘QButtonGroup*’ to ‘const QObject*’
/usr/include/qt5/QtCore/qobject.h:211:36: note: candidate: static QMetaObject::Connection QObject::connect(const QObject*, const QMetaMethod&, const QObject*, const QMetaMethod&, Qt::ConnectionType)
     static QMetaObject::Connection connect(const QObject *sender, const QMetaMethod &signal,
                                    ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:211:36: note:   no known conversion for argument 1 from ‘QButtonGroup*’ to ‘const QObject*’
/usr/include/qt5/QtCore/qobject.h:463:32: note: candidate: QMetaObject::Connection QObject::connect(const QObject*, const char*, const char*, Qt::ConnectionType) const
 inline QMetaObject::Connection QObject::connect(const QObject *asender, const char *asignal,
                                ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:463:32: note:   no known conversion for argument 1 from ‘QButtonGroup*’ to ‘const QObject*’
/usr/include/qt5/QtCore/qobject.h:228:43: note: candidate: template<class Func1, class Func2> static QMetaObject::Connection QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, const typename QtPrivate::FunctionPointer<Func2>::Object*, Func2, Qt::ConnectionType)
     static inline QMetaObject::Connection connect(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal,
                                           ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:228:43: note:   template argument deduction/substitution failed:
/usr/include/qt5/QtCore/qobject.h: In substitution of ‘template<class Func1, class Func2> static QMetaObject::Connection QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, const typename QtPrivate::FunctionPointer<Func2>::Object*, Func2, Qt::ConnectionType) [with Func1 = const char*; Func2 = const char*]’:
qt/sendcoinsdialog.cpp:183:92:   required from here
/usr/include/qt5/QtCore/qobject.h:228:43: error: no type named ‘Object’ in ‘struct QtPrivate::FunctionPointer<const char*>’
/usr/include/qt5/QtCore/qobject.h:260:13: note: candidate: template<class Func1, class Func2> static typename std::enable_if<((int)(QtPrivate::FunctionPointer<Func2>::ArgumentCount) >= 0), QMetaObject::Connection>::type QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, Func2)
             connect(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal, Func2 slot)
             ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:260:13: note:   template argument deduction/substitution failed:
qt/sendcoinsdialog.cpp:183:92: note:   candidate expects 3 arguments, 4 provided
         connect(groupFee, SIGNAL(buttonClicked(int)), this, SLOT(coinControlUpdateLabels()));
                                                                                            ^
In file included from /usr/include/qt5/QtCore/qiodevice.h:45:0,
                 from /usr/include/qt5/QtCore/qdatastream.h:44,
                 from /usr/include/qt5/QtGui/qregion.h:49,
                 from /usr/include/qt5/QtGui/qevent.h:45,
                 from /usr/include/qt5/QtGui/QList:1,
                 from ./qt/paymentrequestplus.h:19,
                 from ./qt/walletmodel.h:13,
                 from ./qt/sendcoinsdialog.h:8,
                 from qt/sendcoinsdialog.cpp:5:
/usr/include/qt5/QtCore/qobject.h:269:13: note: candidate: template<class Func1, class Func2> static typename std::enable_if<(((int)(QtPrivate::FunctionPointer<Func2>::ArgumentCount) >= 0) && (! QtPrivate::FunctionPointer<Func2>::IsPointerToMemberFunction)), QMetaObject::Connection>::type QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, const QObject*, Func2, Qt::ConnectionType)
             connect(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal, const QObject *context, Func2 slot,
             ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:269:13: note:   template argument deduction/substitution failed:
/usr/include/qt5/QtCore/qobject.h: In substitution of ‘template<class Func1, class Func2> static typename std::enable_if<(((int)(QtPrivate::FunctionPointer<Func2>::ArgumentCount) >= 0) && (! QtPrivate::FunctionPointer<Func2>::IsPointerToMemberFunction)), QMetaObject::Connection>::type QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, const QObject*, Func2, Qt::ConnectionType) [with Func1 = const char*; Func2 = const char*]’:
qt/sendcoinsdialog.cpp:183:92:   required from here
/usr/include/qt5/QtCore/qobject.h:269:13: error: no type named ‘type’ in ‘struct std::enable_if<false, QMetaObject::Connection>’
/usr/include/qt5/QtCore/qobject.h:300:13: note: candidate: template<class Func1, class Func2> static typename std::enable_if<(QtPrivate::FunctionPointer<Func2>::ArgumentCount == -1), QMetaObject::Connection>::type QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, Func2)
             connect(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal, Func2 slot)
             ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:300:13: note:   template argument deduction/substitution failed:
qt/sendcoinsdialog.cpp:183:92: note:   candidate expects 3 arguments, 4 provided
         connect(groupFee, SIGNAL(buttonClicked(int)), this, SLOT(coinControlUpdateLabels()));
                                                                                            ^
In file included from /usr/include/qt5/QtCore/qiodevice.h:45:0,
                 from /usr/include/qt5/QtCore/qdatastream.h:44,
                 from /usr/include/qt5/QtGui/qregion.h:49,
                 from /usr/include/qt5/QtGui/qevent.h:45,
                 from /usr/include/qt5/QtGui/QList:1,
                 from ./qt/paymentrequestplus.h:19,
                 from ./qt/walletmodel.h:13,
                 from ./qt/sendcoinsdialog.h:8,
                 from qt/sendcoinsdialog.cpp:5:
/usr/include/qt5/QtCore/qobject.h:308:13: note: candidate: template<class Func1, class Func2> static typename std::enable_if<(QtPrivate::FunctionPointer<Func2>::ArgumentCount == -1), QMetaObject::Connection>::type QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, const QObject*, Func2, Qt::ConnectionType)
             connect(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal, const QObject *context, Func2 slot,
             ^~~~~~~
/usr/include/qt5/QtCore/qobject.h:308:13: note:   template argument deduction/substitution failed:
/usr/include/qt5/QtCore/qobject.h: In substitution of ‘template<class Func1, class Func2> static typename std::enable_if<(QtPrivate::FunctionPointer<Func2>::ArgumentCount == -1), QMetaObject::Connection>::type QObject::connect(const typename QtPrivate::FunctionPointer<Func>::Object*, Func1, const QObject*, Func2, Qt::ConnectionType) [with Func1 = const char*; Func2 = const char*]’:
qt/sendcoinsdialog.cpp:183:92:   required from here
/usr/include/qt5/QtCore/qobject.h:308:13: error: no type named ‘Object’ in ‘struct QtPrivate::FunctionPointer<const char*>’
qt/sendcoinsdialog.cpp: In destructor ‘virtual SendCoinsDialog::~SendCoinsDialog()’:
qt/sendcoinsdialog.cpp:221:44: error: invalid use of incomplete type ‘class QButtonGroup’
     settings.setValue("nFeeRadio", groupFee->checkedId());
                                            ^~
In file included from qt/sendcoinsdialog.cpp:5:0:
./qt/sendcoinsdialog.h:19:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
       ^~~~~~~~~~~~
qt/sendcoinsdialog.cpp:221:46: error: invalid use of incomplete type ‘class QButtonGroup’
     settings.setValue("nFeeRadio", groupFee->checkedId());
                                              ^~~~~~~~~
In file included from qt/sendcoinsdialog.cpp:5:0:
./qt/sendcoinsdialog.h:19:7: note: forward declaration of ‘class QButtonGroup’
 class QButtonGroup;
       ^~~~~~~~~~~~
make[2]: *** [Makefile:8726: qt/libxsnqt_a-sendcoinsdialog.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/home/demouser/XSN-master/src'
make[1]: *** [Makefile:11308: all-recursive] Error 1
make[1]: Leaving directory '/home/demouser/XSN-master/src'
make: *** [Makefile:750: all-recursive] Error 1
```
QT 5.11.2-r1

Adding
```#include <QButtonGroup>```
fixed the issue.